### PR TITLE
Update base.d.ts

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -58,6 +58,7 @@ export interface BaseReactPlayerProps {
   ) => void
   onDuration?: (duration: number) => void
   onSeek?: (seconds: number) => void
+  onPlaybackRateChange?: () => void
   onProgress?: (state: OnProgressProps) => void
   [otherProps: string]: any
 }


### PR DESCRIPTION
onPlaybackRateChange type is not included on type, and is a valid property of imported ReactPlayer.

The correct return is a callback function, called when the user changes playback rate.

Project details

import: 
import ReactPlayer from "react-player";

version:
2.12.0